### PR TITLE
Add GC Loader support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ iplboot will attempt to load DOLs from the following locations in order:
 - SD Gecko in Card Slot B
 - USB Gecko in Card Slot A
 - SD Gecko in Card Slot A
-- GC Loader
 - SD2SP2
+- GC Loader
 
 You can use button shortcuts to keep alternate software on quick access. When loading from an SD card, iplboot will look for and load different filenames depending on what buttons are being held:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ iplboot will attempt to load DOLs from the following locations in order:
 - SD Gecko in Card Slot B
 - USB Gecko in Card Slot A
 - SD Gecko in Card Slot A
+- GC Loader
 - SD2SP2
 
 You can use button shortcuts to keep alternate software on quick access. When loading from an SD card, iplboot will look for and load different filenames depending on what buttons are being held:

--- a/source/fatfs/ff.h
+++ b/source/fatfs/ff.h
@@ -172,7 +172,7 @@ typedef struct {
 	LBA_t	bitbase;		/* Allocation bitmap base sector */
 #endif
 	LBA_t	winsect;		/* Current sector appearing in the win[] */
-	BYTE	win[FF_MAX_SS];	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
+	BYTE	__attribute__((aligned (32))) win[FF_MAX_SS];	/* Disk access window for Directory, FAT (and file data at tiny cfg), must be 32-bit aligned for __io_gcode */
 } FATFS;
 
 

--- a/source/main.c
+++ b/source/main.c
@@ -68,7 +68,7 @@ void load_parse_cli(char *path)
     path[path_length - 1] = 'i';
 
     kprintf("Reading %s\n", path);
-    FIL file;
+    FIL file ATTRIBUTE_ALIGN (32);
     FRESULT result = f_open(&file, path, FA_READ);
     if (result != FR_OK)
     {

--- a/source/main.c
+++ b/source/main.c
@@ -392,6 +392,8 @@ int main()
 
     if (load_fat("sda", &__io_gcsda, paths, num_paths)) goto load;
 
+    if (load_fat("gcl", &__io_gcode, paths, num_paths)) goto load;
+
     if (load_fat("sd2", &__io_gcsd2, paths, num_paths)) goto load;
 
 load:

--- a/source/main.c
+++ b/source/main.c
@@ -173,7 +173,7 @@ int load_fat(const char *slot_name, const DISC_INTERFACE *iface_, char **paths, 
     {
         char *path = paths[i];
         kprintf("Reading %s\n", path);
-        FIL file;
+        FIL file ATTRIBUTE_ALIGN (32);
         FRESULT open_result = f_open(&file, path, FA_READ);
         if (open_result != FR_OK)
         {
@@ -392,9 +392,9 @@ int main()
 
     if (load_fat("sda", &__io_gcsda, paths, num_paths)) goto load;
 
-    if (load_fat("gcl", &__io_gcode, paths, num_paths)) goto load;
-
     if (load_fat("sd2", &__io_gcsd2, paths, num_paths)) goto load;
+
+    if (load_fat("gcl", &__io_gcode, paths, num_paths)) goto load;
 
 load:
     if (!dol)


### PR DESCRIPTION
This PR adds support for loading from GC Loader, currently prioritized last, as trying to read from GC Loader hangs for 10 seconds if no disc drive is present. It's tested and working on my setup when compiled against the latest `libogc2`.

A slight modification was made to the `FATFS` struct to align the disk access window buffer to 32 bits, as `libogc2` [doesn't allow reading from GC Loader when it's not aligned](https://github.com/extremscorner/libogc2/blob/0c551f3b51f940b6d58f397294f069933524b9e5/libogc/dvd.c#L3009). This shouldn't affect anything else. Let me know if there's a known better way to do this.

**Why load from GC Loader when you've got an IPL replacement chip (or, why even install an IPL replacement when you already have a GC Loader)?**
Why not? :) It's always best to give the user more options. One practical reason is so we can use the shortcut buttons which aren't supported with GC Loader right now. Plus, projects like PicoBoot may add deeper features that GC Loader users may want to take advantage of, so it could be even more advantageous in the future to have both installed.