### PR TITLE
Make all UF2 block sizes equal

### DIFF
--- a/buildtools/dol2ipl.py
+++ b/buildtools/dol2ipl.py
@@ -99,7 +99,7 @@ def pack_uf2(data, base_address):
             0x9E5D5157, # Magic 2
             0x00002000, # Flags (family ID present)
             addr,
-            len(chunk),
+            chunk_size,
             seq,
             total_chunks,
             0xE48BFF56, # Board family: Raspberry Pi RP2040


### PR DESCRIPTION
I've started looking into https://github.com/webhdx/PicoBoot/pull/107 and during testing I found out that produced UF2 file is invalid and cannot be programmed to Pico. After further analysis it turns out payload size for every block should be uniform and usually match page size of the flash memory. 