### PR TITLE
Build universal UF2 file compatible with RP2040 and RP2350

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ gekkoboot is bundled with the [PicoBoot] firmware.
 Just follow the [update guide][pb-update].
 
 You can also update gekkoboot separately from the PicoBoot firmware,
-using the supplied `gekkoboot_pico.uf2`, and following the same procedure
+using the supplied `gekkoboot_universal.uf2`, and following the same procedure
 (requires PicoBoot 0.4 or later).
 
 [PicoBoot]: https://github.com/webhdx/PicoBoot

--- a/README.md
+++ b/README.md
@@ -206,8 +206,11 @@ $ meson compile -C build
 # The binaries will be in the build directory
 $ ls build
 ...
+gekkoboot.dol
 gekkoboot_memcard.gci
 gekkoboot_pico.uf2
+gekkoboot_pico2.uf2
+gekkoboot_universal.uf2
 gekkoboot_qoob_pro.gcb
 gekkoboot_viper.vgc
 qoob_pro_gekkoboot_upgrade.elf

--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,8 @@ foreach name, exe: dols
         output: name + '.dol',
         command: [elf2dol, '@INPUT@', '@OUTPUT@'],
         build_by_default: true,
+        install: true,
+        install_dir: '/',
     )
     set_variable(name + '_dol', dol)
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -165,7 +165,27 @@ pico = custom_target(
     'pico',
     input: gekkoboot_dol,
     output: 'gekkoboot_pico.uf2',
-    command: [dol2ipl, '@OUTPUT@', '@INPUT@'],
+    command: [dol2ipl, '@OUTPUT@', '@INPUT@', 'rp2040'],
+    build_by_default: true,
+    install: false,
+    install_dir: '/',
+)
+
+pico2 = custom_target(
+    'pico2',
+    input: gekkoboot_dol,
+    output: 'gekkoboot_pico2.uf2',
+    command: [dol2ipl, '@OUTPUT@', '@INPUT@', 'rp2350'],
+    build_by_default: true,
+    install: false,
+    install_dir: '/',
+)
+
+pico_universal = custom_target(
+    'pico_universal',
+    input: [pico, pico2],
+    output: 'gekkoboot_universal.uf2',
+    command: ['sh', '-c', 'cat "$1" "$2" > "$3"', 'sh', '@INPUT0@', '@INPUT1@', '@OUTPUT@'],
     build_by_default: true,
     install: true,
     install_dir: '/',


### PR DESCRIPTION
PicoBoot is now compatible with Pico 2 boards thanks to https://github.com/webhdx/PicoBoot/pull/129 This requires new payload UF2 files to be created. A nice thing about Pico and UF2 is that we can have a single UF2 file with blocks targeted at different MCUs. It lets us create a single gekkoboot payload compatible with both Pico and Pico 2 boards.

I updated `dol2ipl.py` script to take family id used in uf2 file and updated mason build to produce concatenated uf2 file.
I'm not particularly satisied with:
```
command: ['sh', '-c', 'cat "$1" "$2" > "$3"', 'sh', '@INPUT0@', '@INPUT1@', '@OUTPUT@'],
```

But meson would treat `>` output redirection operator as a string value so I had to figure out a workaround for this.

BTW. I've also added DOL file to build artifacts as it's very convenient for testing and for building PicoBoot in CI pipeline.